### PR TITLE
Adjusted IN/OUT CDArt animations

### DIFF
--- a/720p/MusicVisualisation.xml
+++ b/720p/MusicVisualisation.xml
@@ -687,9 +687,9 @@
 			<!-- CD Animation -->
 			<control type="image">
 				<description>Cd Disc</description>
-					<animation effect="slide" start="-118" end="0" time="900" tween="cubic" easing="out" delay="1000">WindowOpen</animation>
+					<animation effect="slide" start="-100" end="0" time="900" tween="cubic" easing="out" delay="1000">WindowOpen</animation>
 					<animation type="WindowClose">
-					<effect type="slide" start="0" end="-114" time="800" tween="cubic" easing="in" delay="0"/>
+					<effect type="slide" start="0" end="-100" time="800" tween="cubic" easing="in" delay="0"/>
 					<effect type="fade" start="100" end="0" time="1300"/>
 					<condition type="!Player.Playing"/>
 					</animation>


### PR DESCRIPTION
I've modified the start point of the IN animation and the end point of the OUT animation, because with the default settings I can see the cdart behind the cover.
