### PR TITLE
Fixed RSS feed control size when home buttons are hidden

### DIFF
--- a/720p/Home.xml
+++ b/720p/Home.xml
@@ -1465,7 +1465,46 @@
 				<textcolor>blue</textcolor>
 				<titlecolor>blue</titlecolor>
 				<headlinecolor>white</headlinecolor>
-				<visible>!Player.HasAudio</visible>
+				<visible>!Player.HasAudio + !Skin.HasSetting(nopower)</visible> <!-- power button visible -->
+			</control>
+			<control type="rss">
+				<description>RSS feed</description>
+				<posx>57</posx>
+				<posy>0</posy>
+				<height>30</height>
+				<width>1188</width>
+				<font>font12</font>
+				<urlset>1</urlset>
+				<textcolor>blue</textcolor>
+				<titlecolor>blue</titlecolor>
+				<headlinecolor>white</headlinecolor>
+				<visible>!Player.HasAudio + Skin.HasSetting(nopower) + !Skin.HasSetting(nofavourites)</visible> <!-- power hidden, favourites visible -->
+			</control>
+			<control type="rss">
+				<description>RSS feed</description>
+				<posx>14</posx>
+				<posy>0</posy>
+				<height>30</height>
+				<width>1231</width>
+				<font>font12</font>
+				<urlset>1</urlset>
+				<textcolor>blue</textcolor>
+				<titlecolor>blue</titlecolor>
+				<headlinecolor>white</headlinecolor>
+				<visible>!Player.HasAudio + Skin.HasSetting(nopower) + Skin.HasSetting(nofavourites) + !Skin.HasSetting(nosearch)</visible> <!-- power hidden, favourites hidden, search visible -->
+			</control>
+			<control type="rss">
+				<description>RSS feed</description>
+				<posx>0</posx>
+				<posy>0</posy>
+				<height>30</height>
+				<width>1245</width>
+				<font>font12</font>
+				<urlset>1</urlset>
+				<textcolor>blue</textcolor>
+				<titlecolor>blue</titlecolor>
+				<headlinecolor>white</headlinecolor>
+				<visible>!Player.HasAudio + Skin.HasSetting(nopower) + Skin.HasSetting(nofavourites) + Skin.HasSetting(nosearch)</visible> <!-- all 3 buttons hidden -->
 			</control>
 			<control type="image">
 				<posx></posx>
@@ -1505,6 +1544,23 @@
 				<width>220</width>
 				<height>60</height>
 				<texture>HomeButtonsBack.png</texture>
+				<visible>!Skin.HasSetting(nopower)</visible> <!-- power button visible -->
+			</control>
+			<control type="image">
+				<posx>-43</posx>
+				<posy>0</posy>
+				<width>220</width>
+				<height>60</height>
+				<texture>HomeButtonsBack.png</texture>
+				<visible>Skin.HasSetting(nopower) + !Skin.HasSetting(nofavourites)</visible> <!-- power hidden, favourites visible -->
+			</control>
+			<control type="image">
+				<posx>-86</posx>
+				<posy>0</posy>
+				<width>220</width>
+				<height>60</height>
+				<texture>HomeButtonsBack.png</texture>
+				<visible>Skin.HasSetting(nopower) + Skin.HasSetting(nofavourites) + !Skin.HasSetting(nosearch)</visible> <!-- power hidden, favourites hidden, search visible -->
 			</control>
 			<control type="button" id="20">
 				<description>Power push button</description>


### PR DESCRIPTION
Ok, i think your request about the RSS feed is fixed now. 
I could not find another way in the xbmc skinning docs than copying the rss controls for each possible hidden button scenario, each with its own width and visible condition. If there is a more efficient way, let me know.

Another fix: the home button gradient background now also reduces when the appropriate buttons are hidden.
