### PR TITLE
correction for the writer field in the landscape view

### DIFF
--- a/720p/IncludesCodecFlagging.xml
+++ b/720p/IncludesCodecFlagging.xml
@@ -130,7 +130,7 @@
 			<height>57</height>
 			<aspectratio>keep</aspectratio>
 			<texture>flagging/ratings/Germany0.png</texture>
-			<visible>substring(ListItem.mpaa,Germany:o.A.) | substring(ListItem.mpaa, o.A.) | substring(ListItem.mpaa, ab 0) | substring(ListItem.mpaa, Rated 0)</visible>
+			<visible>substring(ListItem.mpaa,Germany:o.A.) | substring(ListItem.mpaa,Germany:o.Al.) |substring(ListItem.mpaa, o.A.) | substring(ListItem.mpaa, ab 0) | substring(ListItem.mpaa, Rated 0)</visible>
 		</control>
 		<control type="image">
 			<description>Germany FSK 6</description>

--- a/720p/IncludesHomeMenuItems.xml
+++ b/720p/IncludesHomeMenuItems.xml
@@ -197,6 +197,12 @@
 			<label>5</label>
 			<onclick>ActivateWindow(Settings)</onclick>
 		</control>
+		<control type="button" id="90120">
+			<include>ButtonHomeSubCommonValues</include>                       
+			<label>[COLOR FF757677]Open[/COLOR][COLOR FF8ABEE2]ELEC[/COLOR]</label>
+			<onclick>RunAddon(os.openelec.settings)</onclick>
+			<visible>System.HasAddon(os.openelec.settings)</visible> 
+		</control>   
 		<control type="button" id="90123">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>7</label>

--- a/720p/ViewVideoLandscape.xml
+++ b/720p/ViewVideoLandscape.xml
@@ -178,9 +178,9 @@
 					<texture>separator.png</texture>
 				</control>
 				<control type="label">
-					<posx>227</posx>
+					<posx>25</posx>
 					<posy>165</posy>
-					<width>380</width>
+					<width>600</width>
 					<height>35</height>
 					<font>font13</font>
 					<textcolor>white</textcolor>
@@ -202,9 +202,9 @@
 					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll) + Control.IsVisible(723)</autoscroll>
 				</control>	
 				<control type="label">
-					<posx>27</posx>
+					<posx>25</posx>
 					<posy>235</posy>
-					<width>380</width>
+					<width>600</width>
 					<height>35</height>
 					<font>font13</font>
 					<textcolor>white</textcolor>


### PR DESCRIPTION
Hi,

the size for the writer field was wrong, this caused an unnecessary wrap if the list of writers where to long. This is now fixed. I also moved the posx for the writer, release and plot fields to the same position. 
